### PR TITLE
Documentation fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+  - 1.4
+  - 1.5
+  - 1.6
+  - tip
+install: go get -v ./collins
+script: go test -v ./collins

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-collins
 
+[![GoDoc](https://godoc.org/github.com/tumblr/go-collins/collins?status.svg)](https://godoc.org/github.com/tumblr/go-collins/collins)
+
 go-collins is a client library for [Collins](http://tumblr.github.io/collins/)
 (our inventory management database) written in Go. It covers the full API and
 allows you to manage your assets and their data from Go applications. It is

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # go-collins
 
 [![GoDoc](https://godoc.org/github.com/tumblr/go-collins/collins?status.svg)](https://godoc.org/github.com/tumblr/go-collins/collins)
+[![Travis CI](https://api.travis-ci.org/tumblr/go-collins.svg)](https://api.travis-ci.org/tumblr/go-collins.svg)
 
 go-collins is a client library for [Collins](http://tumblr.github.io/collins/)
 (our inventory management database) written in Go. It covers the full API and

--- a/collins/doc.go
+++ b/collins/doc.go
@@ -84,5 +84,4 @@ used to navigate through the pages.
 		}
 	}
 */
-
 package collins

--- a/collins/firehose.go
+++ b/collins/firehose.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"gopkg.in/tumblr/go-collins.v0/sseclient"
+	"gopkg.in/tumblr/go-collins.v0/collins/sseclient"
 )
 
 // FirehoseService provides functions to communicate with the collins firehose.


### PR DESCRIPTION
A quick update to fix two things:

1) Removing a newline between the package documentation and the package name which I think is the cause for the package documentation not to show up on godoc.org
2) Adding a badge linking to the documentation to make it extra easy to find

@schallert @Primer42 @sushruta 