### PR TITLE
New client from path

### DIFF
--- a/collins/collins.go
+++ b/collins/collins.go
@@ -137,13 +137,13 @@ func NewClientFromYaml() (*Client, error) {
 		"/etc/collins.yml",
 		"/var/db/collins.yml",
 	}
-	return NewClientFromFiles(yamlPaths)
+	return NewClientFromFiles(yamlPaths...)
 }
 
 // NewClientFromFiles takes an array of paths to look for credentials, and if
 // one of them is successfully parsed it returns a Client.
-func NewClientFromFiles(paths []string) (*Client, error) {
-	f, err := openYamlFile(paths)
+func NewClientFromFiles(paths ...string) (*Client, error) {
+	f, err := openYamlFiles(paths...)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func NewClientFromFiles(paths []string) (*Client, error) {
 	return NewClient(creds.Username, creds.Password, creds.Host)
 }
 
-func openYamlFile(paths []string) (io.Reader, error) {
+func openYamlFiles(paths ...string) (io.Reader, error) {
 	for _, path := range paths {
 		f, err := os.Open(path)
 		if err != nil {

--- a/collins/collins.go
+++ b/collins/collins.go
@@ -140,8 +140,9 @@ func NewClientFromYaml() (*Client, error) {
 	return NewClientFromFiles(yamlPaths...)
 }
 
-// NewClientFromFiles takes an array of paths to look for credentials, and if
-// one of them is successfully parsed it returns a Client.
+// NewClientFromFiles takes an array of paths to look for credentials, and
+// returns a Client based on the first config file that exists and parses
+// correctly. Otherwise, it returns nil and an error.
 func NewClientFromFiles(paths ...string) (*Client, error) {
 	f, err := openYamlFiles(paths...)
 	if err != nil {

--- a/collins/collins_test.go
+++ b/collins/collins_test.go
@@ -119,8 +119,8 @@ func TestNewClientFromYaml_error(t *testing.T) {
 	}
 }
 
-func TestNewClientFromFiles(t *testing.T) {
-	client, err := NewClientFromFiles([]string{"../tests/test_config.yml"})
+func TestNewClientFromFiles_single_file(t *testing.T) {
+	client, err := NewClientFromFiles("../tests/test_config.yml")
 	if err != nil {
 		t.Errorf("Failed to create client: %s", err)
 	}
@@ -130,8 +130,30 @@ func TestNewClientFromFiles(t *testing.T) {
 	}
 }
 
+func TestNewClientFromFiles_multiple_files(t *testing.T) {
+	client, err := NewClientFromFiles("../tests/test_config.yml", "../tests/test_config2.yml")
+	if err != nil {
+		t.Errorf("Failed to create client: %s", err)
+	}
+
+	if client.User != "testuser" || client.Password != "testpassword" {
+		t.Errorf("Failed to parse user or password")
+	}
+}
+
+func TestNewClientFromFiles_multiple_files_with_nonexistant(t *testing.T) {
+	client, err := NewClientFromFiles("../tests/test_config_non_existant.yml", "../tests/test_config2.yml")
+	if err != nil {
+		t.Errorf("Failed to create client: %s", err)
+	}
+
+	if client.User != "secondtestuser" || client.Password != "secondtestpassword" {
+		t.Errorf("Failed to parse user or password")
+	}
+}
+
 func TestNewClientFromFiles_error(t *testing.T) {
-	_, err := NewClientFromFiles([]string{"../tests/test_config_non_existant.yml"})
+	_, err := NewClientFromFiles("../tests/test_config_non_existant.yml")
 	if err == nil {
 		t.Errorf("Did not throw error with non-existant config file.")
 	}

--- a/collins/collins_test.go
+++ b/collins/collins_test.go
@@ -118,3 +118,21 @@ func TestNewClientFromYaml_error(t *testing.T) {
 		t.Errorf("Did not throw error with non-existant config file.")
 	}
 }
+
+func TestNewClientFromFiles(t *testing.T) {
+	client, err := NewClientFromFiles([]string{"../tests/test_config.yml"})
+	if err != nil {
+		t.Errorf("Failed to create client: %s", err)
+	}
+
+	if client.User != "testuser" || client.Password != "testpassword" {
+		t.Errorf("Failed to parse user or password")
+	}
+}
+
+func TestNewClientFromFiles_error(t *testing.T) {
+	_, err := NewClientFromFiles([]string{"../tests/test_config_non_existant.yml"})
+	if err == nil {
+		t.Errorf("Did not throw error with non-existant config file.")
+	}
+}

--- a/tests/test_config2.yml
+++ b/tests/test_config2.yml
@@ -1,0 +1,3 @@
+host: https://collins.example.net
+username: secondtestuser
+password: secondtestpassword


### PR DESCRIPTION
This adds a new way of setting up a collins client by specifying the paths to look for a config file in, based on the feedback in #2. I'm also rewriting `NewClientFromYaml()` slightly to avoid duplicated code by having it use `NewClientFromFiles()`.

Resolves #2 

@tumblr/collins @alex-laties