### PR TITLE
Add new versions of go to test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ go:
   - 1.4
   - 1.5
   - 1.6
+  - 1.7
+  - 1.8
   - tip
 install: go get -v ./collins
 script: go test -v ./collins


### PR DESCRIPTION
Not sure what go looks like internally at tumblr but from this page https://golang.org/doc/devel/release.html it looks like it's only worth trying to keep support for 1.7 and 1.8. I have recently really come to appreciate people who don't break backwards compatibility for no real reason however.