### PR TITLE
Fix power management action attribute

### DIFF
--- a/collins/management.go
+++ b/collins/management.go
@@ -26,7 +26,7 @@ type ProvisionOpts struct {
 // collins.
 func (s ManagementService) powerAction(tag, action string) (*Response, error) {
 	data := struct {
-		Action string
+		Action string `url:"action"`
 	}{action}
 
 	ustr, err := addOptions("api/asset/"+tag+"/power", data)


### PR DESCRIPTION
As reported in by @CaptainYANG, we need to specify the URL parameter name here, otherwise it'll start with a capital letter and the API complains.

Fixes #7.

@tumblr/collins 