### PR TITLE
Add support for asset classification

### DIFF
--- a/collins/asset.go
+++ b/collins/asset.go
@@ -15,13 +15,14 @@ type AssetService struct {
 // The Asset struct contains all the information available about a certain
 // asset.
 type Asset struct {
-	Metadata   `json:"ASSET"`
-	Hardware   `json:"HARDWARE"`
-	Addresses  []Address `json:"ADDRESSES"`
-	LLDP       `json:"LLDP"`
-	IPMI       `json:"IPMI"`
-	Attributes map[string]map[string]string `json:"ATTRIBS"`
-	Power      []Power                      `json:"POWER"`
+	Metadata       `json:"ASSET"`
+	Hardware       `json:"HARDWARE"`
+	Classification `json:"CLASSIFICATION"`
+	Addresses      []Address `json:"ADDRESSES"`
+	LLDP           `json:"LLDP"`
+	IPMI           `json:"IPMI"`
+	Attributes     map[string]map[string]string `json:"ATTRIBS"`
+	Power          []Power                      `json:"POWER"`
 }
 
 // Metadata contains data about the asset such as asset tag, name, state and
@@ -47,6 +48,18 @@ type Hardware struct {
 	NICs   []NIC    `json:"NIC"`
 	Disks  []Disk   `json:"DISK"`
 	Base   `json:"BASE"`
+}
+
+// The Classificaton struct contains information about the asset's classification.
+type Classification struct {
+	ID      int    `json:"ID"`
+	Tag     string `json:"TAG"`
+	State   State  `json:"STATE"`
+	Status  string `json:"STATUS"`
+	Type    string `json:"TYPE"`
+	Created string `json:"CREATED"`
+	Updated string `json:"UPDATED"`
+	Deleted string `json:"DELETED"`
 }
 
 // CPU represents a single physical CPU on an asset.

--- a/collins/asset_test.go
+++ b/collins/asset_test.go
@@ -16,8 +16,8 @@ func TestAssetService_Create(t *testing.T) {
 	if err != nil {
 		t.Errorf("Asset.Create returned error: %v", err)
 	}
-	if asset.Tag != "tag30" {
-		t.Errorf("Asset tag %s, want tag30.", asset.Tag)
+	if asset.Metadata.Tag != "tag30" {
+		t.Errorf("Asset tag %s, want tag30.", asset.Metadata.Tag)
 	}
 }
 
@@ -138,8 +138,8 @@ func TestAssetService_Get(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Asset.Get return error: %v", err)
 	}
-	if asset.Tag != "tag30" {
-		t.Errorf("Asset tag: %v, want tag30", asset.Tag)
+	if asset.Metadata.Tag != "tag30" {
+		t.Errorf("Asset tag: %v, want tag30", asset.Metadata.Tag)
 	}
 }
 

--- a/collins/ipam_test.go
+++ b/collins/ipam_test.go
@@ -155,8 +155,8 @@ func TestIPAMService_AssetFromAddress(t *testing.T) {
 		t.Errorf("IPAMService.AssetFromAddress returned error: %v", err)
 	}
 
-	if asset.Tag != "tag1" {
-		t.Errorf("IPAMService.AssetFromAddress return tag %s, want tag1.", asset.Tag)
+	if asset.Metadata.Tag != "tag1" {
+		t.Errorf("IPAMService.AssetFromAddress return tag %s, want tag1.", asset.Metadata.Tag)
 	}
 }
 

--- a/tests/assets/find_success.json
+++ b/tests/assets/find_success.json
@@ -254,6 +254,16 @@
             "SERIAL": "1234567890"
           }
         },
+        "CLASSIFICATION": {
+            "ID": 1305,
+            "TAG": "app",
+            "STATE": null,
+            "STATUS": "Incomplete",
+            "TYPE": "CONFIGURATION",
+            "CREATED": "2014-09-17T13:47:15",
+            "UPDATED": "2014-09-17T13:50:00",
+            "DELETED": null
+        },
         "LLDP": {
           "INTERFACES": [
             {
@@ -610,6 +620,16 @@
             "VENDOR": "Dell Inc.",
             "SERIAL": ""
           }
+        },
+        "CLASSIFICATION": {
+            "ID": 1305,
+            "TAG": "app",
+            "STATE": null,
+            "STATUS": "Incomplete",
+            "TYPE": "CONFIGURATION",
+            "CREATED": "2014-09-17T13:47:15",
+            "UPDATED": "2014-09-17T13:50:00",
+            "DELETED": null
         },
         "LLDP": {
           "INTERFACES": [

--- a/tests/assets/get_success.json
+++ b/tests/assets/get_success.json
@@ -223,6 +223,16 @@
           }
         ]
       },
+      "CLASSIFICATION": {
+        "ID": 1305,
+        "TAG": "app",
+        "STATE": null,
+        "STATUS": "Incomplete",
+        "TYPE": "CONFIGURATION",
+        "CREATED": "2014-09-17T13:47:15",
+        "UPDATED": "2014-09-17T13:50:00",
+        "DELETED": null
+      },
       "LLDP": {
         "INTERFACES": [
           {


### PR DESCRIPTION
This adds support for [Classification data](https://github.com/tumblr/collins/pull/538) in Asset API responses added in Collins 2.2.0.

I kept to the convention of using the field names from the JSON in structs, which leads to "ambiguous selector" errors because both `Classification` and `Metadata` are both part of `Asset` and have the same field names unless you qualify accesses to the `Metadata` and `Classification` fields. I'm not sure if that convention should be broken here to avoid that or not.

We have signed + submitted the CLA on October 19th.