### PR TITLE
Remove tip and update versions we test with on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: go
 go:
-  - 1.4
-  - 1.5
-  - 1.6
   - 1.7
   - 1.8
-  - tip
+  - 1.9
 install: go get -v ./collins
 script: go test -v ./collins


### PR DESCRIPTION
The tests currently fail if you run them with Go built from `HEAD@master` (see PR #11). They pass on the latest stable, 1.9.1, though. Let's not make life harder than it is by requiring code and tests to work on unreleased Go :)

This replaces `tip` with 1.9 in .travis.yml, and removes Go versions that are now unsupported.