### PR TITLE
Add Asset GPU info

### DIFF
--- a/collins/asset.go
+++ b/collins/asset.go
@@ -44,6 +44,7 @@ type Metadata struct {
 // an asset.
 type Hardware struct {
 	CPUs   []CPU    `json:"CPU"`
+	GPUs   []GPU    `json:"GPU"`
 	Memory []Memory `json:"MEMORY"`
 	NICs   []NIC    `json:"NIC"`
 	Disks  []Disk   `json:"DISK"`
@@ -70,6 +71,13 @@ type CPU struct {
 	Description string  `json:"DESCRIPTION"`
 	Product     string  `json:"PRODUCT"`
 	Vendor      string  `json:"VENDOR"`
+}
+
+// GPU represents a single physical GPU on an asset.
+type GPU struct {
+	Description string `json:"DESCRIPTION"`
+	Product     string `json:"PRODUCT"`
+	Vendor      string `json:"VENDOR"`
 }
 
 // Memory represents a single memory module installed in a bank on the asset.


### PR DESCRIPTION
This adds the asset GPU from collins if available. The fields match the
output as seen in https://github.com/tumblr/collins/blob/master/app/collins/models/lshw/Gpu.scala. Additionally I generated a fake asset with real GPU info and posted
it here
https://gist.github.com/michaeljs1990/c6b4c32f2c79403b8ee4b934d5715062.