### PR TITLE
Add sortField param

### DIFF
--- a/collins/collins.go
+++ b/collins/collins.go
@@ -79,9 +79,10 @@ type Response struct {
 // describe our pagination opts as structs. This also allows embedding of
 // pagination options directly into other request option structs.
 type PageOpts struct {
-	Page int    `url:"page,omitempty"`
-	Size int    `url:"size,omitempty"`
-	Sort string `url:"sort,omitempty"`
+	Page      int    `url:"page,omitempty"`
+	Size      int    `url:"size,omitempty"`
+	Sort      string `url:"sort,omitempty"`
+	SortField string `url:"sortField,omitempty"`
 }
 
 // PaginationResponse is used to represent the pagination information coming


### PR DESCRIPTION
This adds the sortField param that I found when looking through the ruby
collins library. It doesn't seem to be documented any place but it is
mentioned in the docs under CQL sorting "Any single-valued attribute can
be sorted".

I verified on a local install that this is actually valid by sorting against both tag and host.

```
user@rice ~/code/collins-go-cli $ ./collins-go-cli query -sort-ascending -sort-field tag -t M0000001,M0000002
M0000001        plex-8316f3de71.pit1.terame.com plexnode        Allocated       PRODUCTION      PLEX       
M0000002        dev-a7e8c3277b.pit1.terame.com  devnode         Provisioned     DEVELOPMENT     DEVELOPMENT
user@rice ~/code/collins-go-cli $ ./collins-go-cli query -sort-descending -sort-field tag -t M0000001,M0000002
M0000002        dev-a7e8c3277b.pit1.terame.com  devnode         Provisioned     DEVELOPMENT     DEVELOPMENT
M0000001        plex-8316f3de71.pit1.terame.com plexnode        Allocated       PRODUCTION      PLEX       
user@rice ~/code/collins-go-cli $ ./collins-go-cli query -sort-descending -sort-field hostname -t M0000001,M0000002
M0000001        plex-8316f3de71.pit1.terame.com plexnode        Allocated       PRODUCTION      PLEX       
M0000002        dev-a7e8c3277b.pit1.terame.com  devnode         Provisioned     DEVELOPMENT     DEVELOPMENT
user@rice ~/code/collins-go-cli $ ./collins-go-cli query -sort-ascending -sort-field hostname -t M0000001,M0000002
M0000002        dev-a7e8c3277b.pit1.terame.com  devnode         Provisioned     DEVELOPMENT     DEVELOPMENT
M0000001        plex-8316f3de71.pit1.terame.com plexnode        Allocated       PRODUCTION      PLEX       
```

https://github.com/tumblr/collins/blob/379dc8bcdc2ca1374caa90a4425c26696f6e16ef/app/collins/models/shared/Page.scala#L43