### PR TITLE
Collins client changes

### DIFF
--- a/collins/collins.go
+++ b/collins/collins.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -114,11 +113,6 @@ func NewClient(username, password, baseurl string, timeout int) (*Client, error)
 	c := &Client{
 		client: &http.Client{
 			Timeout: time.Duration(timeout) * time.Second,
-			Transport: &http.Transport{
-				Dial: (&net.Dialer{
-					KeepAlive: 60 * time.Second,
-				}).Dial,
-			},
 		},
 		User:     username,
 		Password: password,

--- a/collins/collins_test.go
+++ b/collins/collins_test.go
@@ -20,7 +20,7 @@ func setup() {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 
-	client, _ = NewClient("test", "test", "test")
+	client, _ = NewClient("test", "test", "test", 0)
 	url, _ := url.Parse(server.URL)
 	client.BaseURL = url
 }
@@ -76,7 +76,7 @@ func SetupDELETE(code int, url, file string, contentType string, t *testing.T) {
 }
 
 func TestNewClient(t *testing.T) {
-	client, err := NewClient("testuser", "testpassword", "https://collins.example.net")
+	client, err := NewClient("testuser", "testpassword", "https://collins.example.net", 0)
 	if err != nil {
 		t.Errorf("Failed to create client: %s", err)
 	}


### PR DESCRIPTION
This adds timeout support so it no longer uses the default golang http client behavior or waiting forever. Additionally I added support for reading the config file if the key is a ruby symbol. This brings this closer to the functionality of the collins ruby auth client except it doesn't have any interactive support for if you leave out fields.