### PR TITLE
Add go mod support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module gopkg.in/tumblr/go-collins.v0
+
+require (
+	github.com/google/go-querystring v1.0.0
+	github.com/schallert/iso8601 v0.0.0-20151102174922-d51701471974
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/schallert/iso8601 v0.0.0-20151102174922-d51701471974 h1:MlG1dDfLMkUe5bVS4ImeF9dDLqdi+Zs30kHeBLvehO0=
+github.com/schallert/iso8601 v0.0.0-20151102174922-d51701471974/go.mod h1:AEfUJwBN6Fc76PNQmiOGbjfv3ejIvTQehwLzbUxmPPA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This seems to be the way the golang community is going for dependency management. The biggest thing is that it makes it really easy to test local changes or forks of this repo for other modules using go mod as well. I have been locally generating this file for a while so I can use the following feature when making changes to the go-client locally.

```
replace gopkg.in/tumblr/go-collins.v0 => /home/username/code/go-collins
```