### PR TITLE
Profile support

### DIFF
--- a/collins/management.go
+++ b/collins/management.go
@@ -155,9 +155,9 @@ func (s ManagementService) Provision(tag, profile, contact string, opts Provisio
 	return resp, err
 }
 
-// ListProfiles returns all available profiles for provisioning
+// GetProvisioningProfiles returns all available profiles for provisioning
 // http://tumblr.github.io/collins/api.html#api-asset%20managment-provisioning-profiles
-func (s ManagementService) ListProfiles() ([]Profile, *Response, error) {
+func (s ManagementService) GetProvisioningProfiles() ([]Profile, *Response, error) {
 	ustr, err := addOptions("api/provision/profiles", nil)
 	if err != nil {
 		return nil, nil, err

--- a/collins/management.go
+++ b/collins/management.go
@@ -22,6 +22,20 @@ type ProvisionOpts struct {
 	Contact string `url:"contact"`
 }
 
+// Profile contains all info about a specific provisioning profile
+type Profile struct {
+	Profile               string `json:"PROFILE"`
+	Label                 string `json:"LABEL"`
+	Prefix                string `json:"PREFIX"`
+	SuffixAllowed         bool   `json:"SUFFIX_ALLOWED"`
+	PrimaryRole           string `json:"PRIMARY_ROLE"`
+	RequiresPrimaryRole   bool   `json:"REQUIRES_PRIMARY_ROLE"`
+	Pool                  string `json:"POOL"`
+	RequiresPool          bool   `json:"REQUIRES_POOL"`
+	SecondaryRole         string `json:"SECONDARY_ROLE"`
+	RequiresSecondaryRole bool   `json:"REQUIRES_SECONDARY_ROLE"`
+}
+
 // powerActions is an internal function for performing various power actions via
 // collins.
 func (s ManagementService) powerAction(tag, action string) (*Response, error) {
@@ -139,4 +153,29 @@ func (s ManagementService) Provision(tag, profile, contact string, opts Provisio
 
 	resp, err := s.client.Do(req, nil)
 	return resp, err
+}
+
+// ListProfiles returns all available profiles for provisioning
+// http://tumblr.github.io/collins/api.html#api-asset%20managment-provisioning-profiles
+func (s ManagementService) ListProfiles() ([]Profile, *Response, error) {
+	ustr, err := addOptions("api/provision/profiles", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", ustr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var c struct {
+		Profiles []Profile `json:"PROFILES"`
+	}
+
+	resp, err := s.client.Do(req, &c)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return c.Profiles, resp, nil
 }

--- a/collins/management_test.go
+++ b/collins/management_test.go
@@ -105,3 +105,15 @@ func TestManagementService_Provision_error(t *testing.T) {
 		t.Errorf("ManagementService.Provision did not return error on invalid asset.")
 	}
 }
+
+func TestManagementService_GetProvisioningProfiles(t *testing.T) {
+	setup()
+	defer teardown()
+
+	SetupGET(200, "/api/provision/profiles", "../tests/management/provision_profiles.json", "application/json;", t)
+
+	_, _, err := client.Management.GetProvisioningProfiles()
+	if err != nil {
+		t.Errorf("ManagementService.GetProvisionProfiles returned error: %v", err)
+	}
+}

--- a/collins/management_test.go
+++ b/collins/management_test.go
@@ -114,6 +114,6 @@ func TestManagementService_GetProvisioningProfiles(t *testing.T) {
 
 	_, _, err := client.Management.GetProvisioningProfiles()
 	if err != nil {
-		t.Errorf("ManagementService.GetProvisionProfiles returned error: %v", err)
+		t.Errorf("ManagementService.GetProvisioningProfiles returned error: %v", err)
 	}
 }

--- a/tests/management/provision_profiles.json
+++ b/tests/management/provision_profiles.json
@@ -1,0 +1,31 @@
+{
+  "status": "success:ok",
+  "data": {
+    "PROFILES": [
+      {
+        "PROFILE": "devnode",
+        "LABEL": "Dev Machine",
+        "PREFIX": "dev",
+        "SUFFIX_ALLOWED": true,
+        "PRIMARY_ROLE": "DEVELOPMENT",
+        "REQUIRES_PRIMARY_ROLE": true,
+        "POOL": "DEVELOPMENT",
+        "REQUIRES_POOL": true,
+        "SECONDARY_ROLE": null,
+        "REQUIRES_SECONDARY_ROLE": false
+      },
+      {
+        "PROFILE": "plexnode",
+        "LABEL": "Plex Media Server",
+        "PREFIX": "plex",
+        "SUFFIX_ALLOWED": true,
+        "PRIMARY_ROLE": "PLEX",
+        "REQUIRES_PRIMARY_ROLE": true,
+        "POOL": "PRODUCTION",
+        "REQUIRES_POOL": true,
+        "SECONDARY_ROLE": null,
+        "REQUIRES_SECONDARY_ROLE": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This adds the ability to get a list of all profiles that are currently
available in collins. I added it under the management service for now
because the other /api/provision/* endpoint also was listed under it.