### PR TITLE
Remove gopkg.in and prepare stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,9 @@ project](https://github.com/google/go-github).
 ## Usage
 
 We use [semantic versioning](http://semver.org/) to indicate what the scope of
-changes between versions are. You can use this to ensure breaking changes aren't
-introduced in to your application by using [gopkg.in](http://labix.org/gopkg.in)
-to get the package, and specify the major version there.
-
-```
-import "gopkg.in/tumblr/go-collins.v0/collins"
-```
-
-The current gopkg version is v0, which means that the package is of alpha or
-beta quality. While we do actively use go-collins at Tumblr and will try to
-maintain a stable interface, for now consider this a work-in-progress in that
-breaking changes may be made.
+changes between versions are. Each version is tagged as a release on github, so
+you can use go mod to ensure you are getting the version you expect, and upgrade
+between versions in a safe manner.
 
 To start querying collins, import go-collins and set up a new `Client`
 by using `NewClient()` or `NewClientFromYaml()`. The second function will look
@@ -35,7 +26,7 @@ credentials as parameters.
 import (
 	"fmt"
 
-	"gopkg.in/tumblr/go-collins.v0/collins"
+	"github.com/tumblr/go-collins/collins"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ changes between versions are. Each version is tagged as a release on github, so
 you can use go mod to ensure you are getting the version you expect, and upgrade
 between versions in a safe manner.
 
+If you are not using go modules you can make sure you're using the expected
+major version by using the `gopkg.in` import path:
+
+```
+import "gopkg.in/tumblr/go-collins.v1/collins"
+```
+
 To start querying collins, import go-collins and set up a new `Client`
 by using `NewClient()` or `NewClientFromYaml()`. The second function will look
 for a `collins.yml` file and use credentials from it, while `NewClient()` takes

--- a/collins/doc.go
+++ b/collins/doc.go
@@ -5,10 +5,6 @@ you to manage your assets and their data from Go applications. It is very much
 influenced by the beautiful go-github project
 (https://github.com/google/go-github).
 
-While we do actively use go-collins at Tumblr and will try to maintain a stable
-interface, for now consider this a work-in-progress in that breaking changes may
-be made.
-
 Usage
 
 To start querying collins, import go-collins and set up a new `Client`
@@ -19,7 +15,7 @@ credentials as parameters.
 	import (
 		"fmt"
 
-		"gopkg.in/tumblr/go-collins.v0"
+		"github.com/tumblr/go-collins/collins"
 	)
 
 	func main() {

--- a/collins/firehose.go
+++ b/collins/firehose.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"gopkg.in/tumblr/go-collins.v0/collins/sseclient"
+	"github.com/tumblr/go-collins/collins/sseclient"
 )
 
 // FirehoseService provides functions to communicate with the collins firehose.


### PR DESCRIPTION
This is mostly for discussion really, but since we're now all `go mod`ed up (#23) I don't really see a use for gopkg.in anymore. Instead, I propose we just use git tags and github releases with changelogs since that seems to align with how `go mod` like to do things.

I'd also like to take this opportunity to release the first stable version! There have been some additions since we first released this, but most of them have been additive so I feel it's time to mark this thing as stable. Though we should probably let #22 land first :)

Thoughts?
@tumblr/collins @byxorna @michaeljs1990 @alex-laties